### PR TITLE
Fixed trailing slash issue

### DIFF
--- a/lib/kue-ui.js
+++ b/lib/kue-ui.js
@@ -12,7 +12,7 @@ var config = {};
  */
 var clientRoute = function(req, res) {
     return res.render('build', {
-        baseURL: config.baseURL === '/' ? '' : config.baseURL,
+        baseURL: config.baseURL,
         apiURL: config.apiURL,
         updateInterval: config.updateInterval
     });
@@ -28,6 +28,10 @@ var setup = function(opts) {
     if (opts.apiURL) config.apiURL = opts.apiURL;
     if (opts.baseURL) config.baseURL = opts.baseURL;
     if (opts.updateInterval) config.updateInterval = opts.updateInterval;
+
+    // Remove trailing '/'
+    if (config.apiURL && config.apiURL.slice(-1) === '/') config.apiURL = config.apiURL.slice(0, -1);
+    if (config.baseURL && config.baseURL.slice(-1) === '/') config.baseURL = config.baseURL.slice(0, -1);
 }
 
 // Express app

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "url": "https://github.com/StreetHub/kue-ui/issues"
   },
   "dependencies": {
-    "express": "^3.1.1",
-    "jade": "^1.8.1"
+    "express": "^4.13.4",
+    "jade": "^1.11.0"
   },
   "homepage": "https://github.com/StreetHub/kue-ui",
   "devDependencies": {
-    "kue": "^0.8.10",
+    "kue": "^0.11.0",
     "load-grunt-tasks": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-html2jade": "^0.2.0",


### PR DESCRIPTION
This config worked fine:
    var uiConf = {
        apiURL: '/kue/',
        baseURL: '/kue2',
        updateInterval: 5000 // Fetches new data every 5000 ms
    };

```
kueui.setup(uiConf);
app.use(uiConf.apiURL, kue.app);
app.use(uiConf.baseURL, kueui.app);
```

But this one broke:
        apiURL: '/',
        baseURL: '/raw',

Now both are handled correctly
